### PR TITLE
Backport the one test that was present in glucometerutils.

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2019 Anthony Sottile
+#
+# SPDX-License-Identifier: MIT
+
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+    - name: set PY
+      run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
+    - uses: pre-commit/action@v1.1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2013 The freestyle-hid Authors
+#
+# SPDX-License-Identifier: 0BSD
+
+dist: xenial
+
+language: python
+
+matrix:
+  include:
+    - python: 3.7
+    - python: 3.8
+      env: PYTEST_OPTIONS="--mypy"
+    - python: 3.9-dev
+
+install:
+  - pip install .[dev]
+
+script:
+  - pytest $PYTEST_OPTIONS

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - python: 3.9-dev
 
 install:
-  - pip install .[dev]
+  - pip install .[dev,tools]
 
 script:
   - pytest $PYTEST_OPTIONS

--- a/freestyle_hid/tests/__init__.py
+++ b/freestyle_hid/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2013 The freestyle-hid Authors
+#
+# SPDX-License-Identifier: 0BSD

--- a/freestyle_hid/tests/test_freestyle.py
+++ b/freestyle_hid/tests/test_freestyle.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: © 2019 The freestyle-hid Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the common FreeStyle functions.."""
+
+# pylint: disable=protected-access,missing-docstring
+
+import unittest
+
+from freestyle_hid import _session
+
+
+class TestFreeStyle(unittest.TestCase):
+    def test_outgoing_command(self):
+        """Test the generation of a new outgoing message."""
+
+        self.assertEqual(
+            b"\0\x17\7command\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
+            b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0",
+            _session._FREESTYLE_MESSAGE.build(
+                {"message_type": 23, "command": b"command"}
+            ),
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,14 @@ known_first_party = ['glucometerutils']
 known_third_party = ['construct', 'hidapi', 'pyscsi', 'serial', 'usbmon']
 
 [tool.setuptools_scm]
+
+[tool.pytest.ini_options]
+addopts = "--color=yes --ignore=setup.py -ra"
+timeout = 120
+norecursedirs = [
+  '.env',
+  '.git',
+  'dist',
+  'build',
+  'venv',
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ hidapi =
 tools =
     click
     click_log
+    usbmon-tools
 dev =
     mypy
     pre-commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,9 @@ tools =
 dev =
     mypy
     pre-commit
+    pytest-mypy
+    pytest-timeout>=1.3.0
+    pytest>=6.0
     setuptools_scm
 
 [options.package_data]


### PR DESCRIPTION
## Backport the one test that was present in glucometerutils.

This also sets up the whole pytest configuration and Travis CI integration.

## Make sure to install usbmon-tools when enabling tools.

Also make sure to install tools when running tests.

## Add missing pre-commit action configuration.
