### PR TITLE
## Allow selecting which encoding to use for decoding text commands.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ matrix:
   include:
     - python: 3.7
     - python: 3.8
+    - python: 3.9
       env: PYTEST_OPTIONS="--mypy"
-    - python: 3.9-dev
+    - python: 3.10-dev
 
 install:
   - pip install .[dev,tools]

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
     - python: 3.10-dev
 
 install:
+  # Work around failures with Python 3.7 on Travis CI coming with its own
+  # version of attrs that is incompatible with pytest.
+  - pip install -U attrs
   - pip install .[dev,tools]
 
 script:

--- a/freestyle_hid/tools/hid_console.py
+++ b/freestyle_hid/tools/hid_console.py
@@ -39,6 +39,13 @@ click_log.basic_config(logger)
     type=int,
     help="Optional product ID (in alternative to the device path)",
 )
+@click.option(
+    "--encoding",
+    "-e",
+    type=str,
+    help="Encoding to use to decode commands returned by the meter",
+    default="ascii",
+)
 @click.argument(
     "device-path",
     type=click.Path(exists=True, dir_okay=False, writable=True, allow_dash=False),
@@ -51,6 +58,7 @@ def main(
     text_reply_type: int,
     product_id: Optional[int],
     device_path: Optional[pathlib.Path],
+    encoding: str,
 ):
     if not product_id and not device_path:
         raise click.UsageError(
@@ -58,7 +66,7 @@ def main(
         )
 
     session = freestyle_hid.Session(
-        product_id, device_path, text_command_type, text_reply_type
+        product_id, device_path, text_command_type, text_reply_type, encoding=encoding
     )
 
     session.connect()


### PR DESCRIPTION
## Calculate multirecords checksum based on the raw bytes.

The original FreeStyle Libre software is known for incorrectly
truncating strings with UTF-8, which causes the multi-record strings not
to decode correctly.

But since the Libre actually sends these as they are provided, we can
calculate the checksum correctly if we do that _before_ replacing the
invalid codepoints.

This splits the `send_text_command` method into a public and a private
interface, with the public returning the expected string, while the
private returns the raw bytes. It should probably be changed to always
return bytes instead.

This change fixes https://github.com/glucometers-tech/glucometerutils/issues/103.

## Allow selecting which encoding to use for decoding text commands.

The FreeStyle Libre at least allows patient names and other strings to
be set in UTF-8 so there is no reason to force ascii everywhere.

Instead, allow the session to define an encoding for ease of integration
with downstream tools.

## travis-ci: update to include 3.10-dev and 3.9 final.


## travis-ci: work around the wrong version of attrs in Python 3.7
