### PR TITLE
CI Updates.

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -24,6 +24,7 @@ jobs:
       run: |
         python -m build --sdist --wheel --outdir dist/ .
     - name: Publish package to TestPyPI
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 jobs:
-  test:
+  pytest:
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,15 +6,15 @@ pull_request_rules:
   - name: Automatic merge on approval
     conditions:
       - "#approved-reviews-by>=1"
-      - "status-success=test (ubuntu-latest, 3.7)"
-      - "status-success=test (ubuntu-latest, 3.8)"
-      - "status-success=test (ubuntu-latest, 3.9)"
-      - "status-success=test (macos-latest, 3.7)"
-      - "status-success=test (macos-latest, 3.8)"
-      - "status-success=test (macos-latest, 3.9)"
-      - "status-success=test (windows-latest, 3.7)"
-      - "status-success=test (windows-latest, 3.8)"
-      - "status-success=test (windows-latest, 3.9)"
+      - "status-success=pytest (ubuntu-latest, 3.7)"
+      - "status-success=pytest (ubuntu-latest, 3.8)"
+      - "status-success=pytest (ubuntu-latest, 3.9)"
+      - "status-success=pytest (macos-latest, 3.7)"
+      - "status-success=pytest (macos-latest, 3.8)"
+      - "status-success=pytest (macos-latest, 3.9)"
+      - "status-success=pytest (windows-latest, 3.7)"
+      - "status-success=pytest (windows-latest, 3.8)"
+      - "status-success=pytest (windows-latest, 3.9)"
       - "status-success=pre-commit"
     actions:
       merge:
@@ -22,15 +22,15 @@ pull_request_rules:
   - name: Automatic merge from Flameeyes
     conditions:
       - "author=Flameeyes"
-      - "status-success=test (ubuntu-latest, 3.7)"
-      - "status-success=test (ubuntu-latest, 3.8)"
-      - "status-success=test (ubuntu-latest, 3.9)"
-      - "status-success=test (macos-latest, 3.7)"
-      - "status-success=test (macos-latest, 3.8)"
-      - "status-success=test (macos-latest, 3.9)"
-      - "status-success=test (windows-latest, 3.7)"
-      - "status-success=test (windows-latest, 3.8)"
-      - "status-success=test (windows-latest, 3.9)"
+      - "status-success=pytest (ubuntu-latest, 3.7)"
+      - "status-success=pytest (ubuntu-latest, 3.8)"
+      - "status-success=pytest (ubuntu-latest, 3.9)"
+      - "status-success=pytest (macos-latest, 3.7)"
+      - "status-success=pytest (macos-latest, 3.8)"
+      - "status-success=pytest (macos-latest, 3.9)"
+      - "status-success=pytest (windows-latest, 3.7)"
+      - "status-success=pytest (windows-latest, 3.8)"
+      - "status-success=pytest (windows-latest, 3.9)"
       - "status-success=pre-commit"
     actions:
       merge:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,7 +6,15 @@ pull_request_rules:
   - name: Automatic merge on approval
     conditions:
       - "#approved-reviews-by>=1"
-      - "status-success=pytest"
+      - "status-success=test (ubuntu-latest, 3.7)"
+      - "status-success=test (ubuntu-latest, 3.8)"
+      - "status-success=test (ubuntu-latest, 3.9)"
+      - "status-success=test (macos-latest, 3.7)"
+      - "status-success=test (macos-latest, 3.8)"
+      - "status-success=test (macos-latest, 3.9)"
+      - "status-success=test (windows-latest, 3.7)"
+      - "status-success=test (windows-latest, 3.8)"
+      - "status-success=test (windows-latest, 3.9)"
       - "status-success=pre-commit"
     actions:
       merge:
@@ -14,7 +22,15 @@ pull_request_rules:
   - name: Automatic merge from Flameeyes
     conditions:
       - "author=Flameeyes"
-      - "status-success=pytest"
+      - "status-success=test (ubuntu-latest, 3.7)"
+      - "status-success=test (ubuntu-latest, 3.8)"
+      - "status-success=test (ubuntu-latest, 3.9)"
+      - "status-success=test (macos-latest, 3.7)"
+      - "status-success=test (macos-latest, 3.8)"
+      - "status-success=test (macos-latest, 3.9)"
+      - "status-success=test (windows-latest, 3.7)"
+      - "status-success=test (windows-latest, 3.8)"
+      - "status-success=test (windows-latest, 3.9)"
       - "status-success=pre-commit"
     actions:
       merge:


### PR DESCRIPTION
Without this change, setuptools_scm will try to publish PEP 440 local
versions to PyPI, which will fail.

Also this does not require checking out the full history.